### PR TITLE
Replace remaining occurrences of ambiguous 'byte' type with 'BYTE'

### DIFF
--- a/include/thunks.hpp
+++ b/include/thunks.hpp
@@ -54,7 +54,7 @@ namespace lunaticpp {
 #pragma code_seg(push, rtext, ".text")
             __declspec(selectany)
                 __declspec(allocate(".text"))
-                extern const byte _trampoline_for_static_thunk[25]{
+                extern const BYTE _trampoline_for_static_thunk[25]{
 
                 // sub         rsp, 18h 
                 //
@@ -262,7 +262,7 @@ namespace lunaticpp {
 #endif
 
 
-            byte* m_code_thunk_bytes;
+            BYTE* m_code_thunk_bytes;
         public:
             inline static constexpr call_type m_call{ _call };
 
@@ -312,7 +312,7 @@ namespace lunaticpp {
 
                 static_assert(sizeof(call_type) == aux::memfunc_size< sizeof(call_type) >::size);
 
-                m_code_thunk_bytes = reinterpret_cast<byte*>(VirtualAlloc(NULL, sizeof(code_thunk_t), MEM_COMMIT, PAGE_READWRITE));
+                m_code_thunk_bytes = reinterpret_cast<BYTE*>(VirtualAlloc(NULL, sizeof(code_thunk_t), MEM_COMMIT, PAGE_READWRITE));
                 {
                     auto code_thunk = reinterpret_cast<code_thunk_t*>(m_code_thunk_bytes);
                     union { DWORD func; call_type call; } addr;
@@ -408,7 +408,7 @@ namespace lunaticpp {
                 //
                 //
 
-                m_code_thunk_bytes = reinterpret_cast<byte*>(VirtualAlloc(NULL, alloc_size, MEM_COMMIT, PAGE_READWRITE));
+                m_code_thunk_bytes = reinterpret_cast<BYTE*>(VirtualAlloc(NULL, alloc_size, MEM_COMMIT, PAGE_READWRITE));
                 {
                     union { DWORD_PTR func; call_type call; } addr;
                     addr.call = m_call;

--- a/include/thunks.hpp
+++ b/include/thunks.hpp
@@ -525,7 +525,7 @@ namespace lunaticpp {
             {
                 static_assert(sizeof(call_type) == aux::memfunc_size< sizeof(call_type) >::size);
 
-                m_code_thunk_bytes = reinterpret_cast<byte*>(VirtualAlloc(NULL, sizeof(code_thunk_t), MEM_COMMIT, PAGE_READWRITE));
+                m_code_thunk_bytes = reinterpret_cast<BYTE*>(VirtualAlloc(NULL, sizeof(code_thunk_t), MEM_COMMIT, PAGE_READWRITE));
                 {
                     auto code_thunk = reinterpret_cast<code_thunk_t*>(m_code_thunk_bytes);
                     union { DWORD_PTR func; call_type call; } addr;


### PR DESCRIPTION
The use of `byte` causes compilation to fail in MSVC 2019:

```
N:\Documenten\Projecten\Other\windows_thunks\include\thunks.hpp(57,35): error C2872: 'byte': ambiguous symbol
C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\shared\rpcndr.h(191,23): message : could be 'unsigned char byte'
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.24.28314\include\cstddef(29,12): message : or       'std::byte'
```